### PR TITLE
Added blake2b hash algorithm to list

### DIFF
--- a/hash-alg.csv
+++ b/hash-alg.csv
@@ -17,6 +17,7 @@ ID,Hash Name String,Value Length,Reference,Status
 15,crc32c,32 bits,[RFC4960](https://tools.ietf.org/html/rfc4960#appendix-B),current
 16,trunc512,192 bits,[GA4GH Refget](https://samtools.github.io/hts-specs/refget.html#trunc512-algorithm-details),current
 17,sha1,160 bits,[FIPS 180-4](https://dx.doi.org/10.6028/NIST.FIPS.180-4),current
-18-31,Unassigned,,,
+18,blake2b-512,512 bits,[RFC7693](https://tools.ietf.org/html/rfc7693),current
+19-31,Unassigned,,,
 32,Reserved,,[RFC6920](http://www.iana.org/go/rfc6920),
 33-63,Unassigned,,,


### PR DESCRIPTION
This PR will add [blake2b](https://tools.ietf.org/html/rfc7693) hash algorithm to the table.

Needs formal review by @ga4gh-discovery